### PR TITLE
Fix #32: URL-encode mastodon status links

### DIFF
--- a/garden/garden.11tydata.js
+++ b/garden/garden.11tydata.js
@@ -36,8 +36,9 @@ async function postNewStatus(data) {
     setTimeout(resolve, Math.random() * 2000);
   });
 
+  const url = encodeURI(`https://travisbriggs.com${data.page.url}`);
   body = JSON.stringify({
-    status: `New garden node! "${data.title}":\n\nhttps://travisbriggs.com${data.page.url}\n\nPublic replies to this status will be posted on the site.`,
+    status: `New garden node! "${data.title}":\n\n${url}\n\nPublic replies to this status will be posted on the site.`,
     visibility: 'public',
   });
   const resp = await fetch('https://mastodon.online/api/v1/statuses', {


### PR DESCRIPTION
## Summary
- Garden nodes whose slugs contain spaces (e.g. `garden/vibe coding.md` → `/garden/vibe coding/`) generated Mastodon status posts where the link broke at the space character, since Mastodon's linkifier terminates on whitespace.
- Wraps the constructed URL in `encodeURI()` so spaces become `%20` while the `:` and `/` separators are preserved.

Closes #32

## Test plan
- [ ] Verify a new garden node with a space in the filename posts a working clickable link to Mastodon (e.g. `https://travisbriggs.com/garden/vibe%20coding/`).
- [ ] Existing single-word slugs still post unchanged (`encodeURI` is a no-op on URLs that have no characters needing encoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)